### PR TITLE
COMPASS-3481: Split readonly and redonly view concepts

### DIFF
--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -77,16 +77,6 @@ const dataService = new DataService(connection);
 appRegistry.emit('data-service-initialized', dataService);
 dataService.connect((error, ds) => {
   appRegistry.emit('data-service-connected', error, ds);
-
-  const query = {
-    filter: { name: 'testing' },
-    project: { name: 1 },
-    sort: { name: -1 },
-    skip: 0,
-    limit: 20,
-    ns: 'citibike.trips'
-  };
-  appRegistry.emit('query-changed', query);
   appRegistry.emit('fields-changed', {
     fields: {
       harry: {
@@ -110,6 +100,7 @@ dataService.connect((error, ds) => {
         version: '0.0.0' }
     ]
   });
+  appRegistry.emit('collection-changed', 'citibike.trips');
 });
 
 if (module.hot) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "ignore": [
       "react-dom",
       "debug",
-      "hadron-react-buttons"
+      "hadron-react-buttons",
+      "mongodb-ns"
     ]
   },
   "license": "Apache-2.0",
@@ -153,6 +154,7 @@
     "lodash.sortbyorder": "^3.4.4",
     "lodash.trim": "^4.5.1",
     "lodash.zipobject": "^4.1.3",
+    "mongodb-ns": "^2.0.0",
     "numeral": "^2.0.6",
     "react-bootstrap": "^0.32.1"
   }

--- a/src/components/indexes/indexes.jsx
+++ b/src/components/indexes/indexes.jsx
@@ -29,6 +29,7 @@ class Indexes extends PureComponent {
   static propTypes = {
     isWritable: PropTypes.bool.isRequired,
     isReadonly: PropTypes.bool.isRequired,
+    isReadonlyView: PropTypes.bool.isRequired,
     description: PropTypes.string.isRequired,
     indexes: PropTypes.array.isRequired,
     sortColumn: PropTypes.string.isRequired,
@@ -68,7 +69,7 @@ class Indexes extends PureComponent {
   }
 
   renderBanner() {
-    if (this.props.isReadonly) {
+    if (this.props.isReadonlyView) {
       return (
         <StatusRow style="warning">
           Readonly views may not contain indexes.
@@ -83,7 +84,7 @@ class Indexes extends PureComponent {
   }
 
   renderCreateIndexButton() {
-    if (!this.props.isReadonly && (this.props.error === null || this.props.error === undefined)) {
+    if (!this.props.isReadonly && !this.props.isReadonlyView && (this.props.error === null || this.props.error === undefined)) {
       return (
         <CreateIndexButton
           toggleIsVisible={this.props.toggleIsVisible}
@@ -115,7 +116,7 @@ class Indexes extends PureComponent {
           {this.renderCreateIndexButton()}
           {this.renderDropIndexModal()}
         </div>
-        {(this.props.isReadonly || !(this.props.error === null || this.props.error === undefined)) ?
+        {(this.props.isReadonlyView || !(this.props.error === null || this.props.error === undefined)) ?
           this.renderBanner() :
           this.renderComponent()}
       </div>
@@ -134,6 +135,7 @@ const mapStateToProps = (state) => ({
   indexes: state.indexes,
   isWritable: state.isWritable,
   isReadonly: state.isReadonly,
+  isReadonlyView: state.isReadonlyView,
   description: state.description,
   error: state.error,
   dataService: state.dataService,

--- a/src/components/indexes/indexes.spec.js
+++ b/src/components/indexes/indexes.spec.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import Indexes from 'components/indexes';
-import store from 'stores';
+import { Indexes } from 'components/indexes';
 import styles from './indexes.less';
 
 import CreateIndexButton from 'components/create-index-button';
@@ -11,16 +10,32 @@ import { StatusRow } from 'hadron-react-components';
 import IndexHeader from 'components/index-header';
 import IndexList from 'components/index-list';
 
-import { readStateChanged } from 'modules/is-readonly';
-import { handleError } from 'modules/error';
-import { reset } from 'modules/reset';
-
+/* eslint react/jsx-boolean-value: 0 */
 describe('indexes [Component]', () => {
   let component;
+  const sortIndexesSpy = sinon.spy();
+  const toggleIsVisibleSpy = sinon.spy();
+  const resetSpy = sinon.spy();
+  const changeNameSpy = sinon.spy();
+  const openLinkSpy = sinon.spy();
 
-  describe('not readonly', () => {
+  context('when the collection is not a readonly view', () => {
     beforeEach(() => {
-      component = mount(<Indexes store={store} />);
+      component = mount(
+        <Indexes
+          isWritable={true}
+          isReadonly={false}
+          isReadonlyView={false}
+          description="testing"
+          indexes={[]}
+          sortColumn="Name and Definition"
+          sortOrder="asc"
+          sortIndexes={sortIndexesSpy}
+          toggleIsVisible={toggleIsVisibleSpy}
+          reset={resetSpy}
+          changeName={changeNameSpy}
+          openLink={openLinkSpy} />
+      );
     });
 
     afterEach(() => {
@@ -44,20 +59,32 @@ describe('indexes [Component]', () => {
       expect(component.find(StatusRow)).to.not.be.present();
     });
 
-    it('renders the main column', () => {
+    it('renders the list and header', () => {
       expect(component.find(IndexHeader)).to.be.present();
       expect(component.find(IndexList)).to.be.present();
     });
   });
 
-  describe('readonly', () => {
+  context('when the collection is a readonly view', () => {
     beforeEach(() => {
-      store.dispatch(readStateChanged(true));
-      component = mount(<Indexes store={store} />);
+      component = mount(
+        <Indexes
+          isWritable={true}
+          isReadonly={false}
+          isReadonlyView={true}
+          description="testing"
+          indexes={[]}
+          sortColumn="Name and Definition"
+          sortOrder="asc"
+          sortIndexes={sortIndexesSpy}
+          toggleIsVisible={toggleIsVisibleSpy}
+          reset={resetSpy}
+          changeName={changeNameSpy}
+          openLink={openLinkSpy} />
+      );
     });
 
     afterEach(() => {
-      store.dispatch(reset());
       component = null;
     });
 
@@ -81,20 +108,79 @@ describe('indexes [Component]', () => {
       );
     });
 
-    it('renders the main column', () => {
+    it('does not render the list or header', () => {
       expect(component.find(IndexHeader)).to.not.be.present();
       expect(component.find(IndexList)).to.not.be.present();
     });
   });
 
-  describe('error', () => {
+  context('when the distribution is readonly', () => {
     beforeEach(() => {
-      store.dispatch(handleError('a test error'));
-      component = mount(<Indexes store={store}/>);
+      component = mount(
+        <Indexes
+          isWritable={true}
+          isReadonly={true}
+          isReadonlyView={false}
+          description="testing"
+          indexes={[]}
+          sortColumn="Name and Definition"
+          sortOrder="asc"
+          sortIndexes={sortIndexesSpy}
+          toggleIsVisible={toggleIsVisibleSpy}
+          reset={resetSpy}
+          changeName={changeNameSpy}
+          openLink={openLinkSpy} />
+      );
     });
 
     afterEach(() => {
-      store.dispatch(reset());
+      component = null;
+    });
+
+    it('renders the correct root classname', () => {
+      expect(component.find(`.${styles.indexes}`)).to.be.present();
+    });
+
+    it('does not render a create-index-button', () => {
+      expect(component.find(CreateIndexButton)).to.not.be.present();
+    });
+
+    it('does not render the controls container', () => {
+      expect(component.find(CreateIndexButton)).to.not.be.present();
+      expect(component.find(DropIndexModal)).to.be.present();
+    });
+
+    it('does not render a status row', () => {
+      expect(component.find(StatusRow)).to.not.be.present();
+    });
+
+    it('renders the main column', () => {
+      expect(component.find(IndexHeader)).to.be.present();
+      expect(component.find(IndexList)).to.be.present();
+    });
+  });
+
+  context('when there is an error', () => {
+    beforeEach(() => {
+      component = mount(
+        <Indexes
+          isWritable={true}
+          isReadonly={false}
+          isReadonlyView={false}
+          description="testing"
+          indexes={[]}
+          sortColumn="Name and Definition"
+          sortOrder="asc"
+          error="a test error"
+          sortIndexes={sortIndexesSpy}
+          toggleIsVisible={toggleIsVisibleSpy}
+          reset={resetSpy}
+          changeName={changeNameSpy}
+          openLink={openLinkSpy} />
+      );
+    });
+
+    afterEach(() => {
       component = null;
     });
 

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -8,6 +8,9 @@ import isWritable, {
 import isReadonly, {
   INITIAL_STATE as READ_INITIAL_STATE
 } from 'modules/is-readonly';
+import isReadonlyView, {
+  INITIAL_STATE as READONLY_VIEW_INITIAL_STATE
+} from 'modules/is-readonly-view';
 import description, {
   INITIAL_STATE as DESCRIPTION_INITIAL_STATE
 } from 'modules/description';
@@ -31,6 +34,7 @@ const reducer = combineReducers({
   indexes,
   isWritable,
   isReadonly,
+  isReadonlyView,
   description,
   appRegistry,
   dataService,
@@ -53,6 +57,7 @@ const rootReducer = (state, action) => {
       ...state,
       isWritable: WRITABLE_INITIAL_STATE,
       isReadonly: READ_INITIAL_STATE,
+      isReadonlyView: READONLY_VIEW_INITIAL_STATE,
       description: DESCRIPTION_INITIAL_STATE,
       indexes: INDEXES_INITIAL_STATE,
       sortOrder: SORT_ORDER_INITIAL_STATE,

--- a/src/modules/is-readonly-view.js
+++ b/src/modules/is-readonly-view.js
@@ -1,0 +1,35 @@
+/**
+ * The readonly view changed action name.
+ */
+export const READONLY_VIEW_CHANGED = 'indexes/is-readonly-view/READONLY_VIEW_CHANGED';
+
+/**
+ * The initial state of the is readonly view attribute.
+ */
+export const INITIAL_STATE = false;
+
+/**
+ * Reducer function for is readonly view state.
+ *
+ * @param {Boolean} state - The state.
+ *
+ * @returns {Boolean} The state.
+ */
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === READONLY_VIEW_CHANGED) {
+    return action.isReadonlyView;
+  }
+  return state;
+}
+
+/**
+ * Action creator for readonly view changed events.
+ *
+ * @param {Boolean} isReadonlyView - Is the view readonly.
+ *
+ * @returns {Object} The readonly view changed action.
+ */
+export const readonlyViewChanged = (isReadonlyView) => ({
+  type: READONLY_VIEW_CHANGED,
+  isReadonlyView: isReadonlyView
+});

--- a/src/modules/is-readonly-view.spec.js
+++ b/src/modules/is-readonly-view.spec.js
@@ -1,0 +1,26 @@
+import reducer, { readonlyViewChanged, READONLY_VIEW_CHANGED } from 'modules/is-readonly-view';
+
+describe('is readonly view module', () => {
+  describe('#reducer', () => {
+    context('when an action is not READONLY_VIEW_CHANGED', () => {
+      it('returns the state', () => {
+        expect(reducer(false, { type: 'test' })).to.equal(false);
+      });
+    });
+
+    context('when an action is READONLY_VIEW_CHANGED', () => {
+      it('returns the new state', () => {
+        expect(reducer(undefined, readonlyViewChanged(true))).to.equal(true);
+      });
+    });
+  });
+
+  describe('#readonlyViewChanged', () => {
+    it('returns the action', () => {
+      expect(readonlyViewChanged(true)).to.deep.equal({
+        type: READONLY_VIEW_CHANGED,
+        isReadonlyView: true
+      });
+    });
+  });
+});

--- a/src/modules/is-readonly.js
+++ b/src/modules/is-readonly.js
@@ -1,44 +1,15 @@
 /**
  * The initial state of the is readonly attribute.
  */
-export const INITIAL_STATE = (process.env.HADRON_READONLY === 'true');
+export const INITIAL_STATE = (process.env.HADRON_READONLY === 'true') ? true : false;
 
 /**
- * The module action prefix.
- */
-const PREFIX = 'indexes';
-
-/**
- * The isReadonly action type.
- */
-export const READ_STATE_CHANGED = `${PREFIX}/is-readonly/READ_STATE_CHANGED`;
-
-/**
- * Reducer function for handle state changes to isReadonly.
+ * Reducer function doesn't do anything since we're based on process.
  *
- * @param {Boolean} state - The status state.
- * @param {Object} action - The action.
+ * @param {Array} state - The state.
  *
- * @returns {Boolean} The new state.
+ * @returns {Array} The state.
  */
-const reducer = (state = INITIAL_STATE, action) => {
-  if (action.type === READ_STATE_CHANGED) {
-    return action.isReadonly;
-  }
+export default function reducer(state = INITIAL_STATE) {
   return state;
-};
-
-export default reducer;
-
-/**
- * Action creator for isReadonly events.
- *
- * @param {Boolean} isReadonly
- * @returns {Object} The isReadonly action.
- */
-export const readStateChanged = (isReadonly) => ({
-  type: READ_STATE_CHANGED,
-  isReadonly: isReadonly
-});
-
-
+}

--- a/src/modules/is-readonly.spec.js
+++ b/src/modules/is-readonly.spec.js
@@ -1,53 +1,9 @@
-import reducer, { readStateChanged, INITIAL_STATE } from 'modules/is-readonly';
+import reducer, { INITIAL_STATE } from 'modules/is-readonly';
 
 describe('is readonly module', () => {
   describe('#reducer', () => {
-    context('when the HADRON_READONLY env is false', () => {
-      before(() => {
-        process.env.HADRON_READONLY = 'false';
-      });
-
-      context('when an action is provided with false', () => {
-        it('returns the new state', () => {
-          expect(reducer(undefined, readStateChanged(false))).to.equal(false);
-        });
-      });
-
-      context('when an action is provided with true', () => {
-        it('returns the new state', () => {
-          expect(reducer(undefined, readStateChanged(true))).to.equal(true);
-        });
-      });
-
-      context('when an action is not provided', () => {
-        it('returns the default state', () => {
-          expect(reducer(undefined, {})).to.equal(INITIAL_STATE);
-        });
-      });
-    });
-  });
-
-  context('when the HADRON_READONLY env is true', () => {
-    before(() => {
-      process.env.HADRON_READONLY = 'true';
-    });
-
-    context('when an action is provided with false', () => {
-      it('returns the new state', () => {
-        expect(reducer(undefined, readStateChanged(false))).to.equal(false);
-      });
-    });
-
-    context('when an action is provided with true', () => {
-      it('returns the new state', () => {
-        expect(reducer(undefined, readStateChanged(true))).to.equal(true);
-      });
-    });
-
-    context('when an action is not provided', () => {
-      it('returns the default state', () => {
-        expect(reducer(undefined, {})).to.equal(INITIAL_STATE);
-      });
+    it('returns the default state', () => {
+      expect(reducer(undefined, {})).to.equal(INITIAL_STATE);
     });
   });
 });

--- a/src/stores/store.spec.js
+++ b/src/stores/store.spec.js
@@ -64,13 +64,13 @@ describe('IndexesStore [Store]', () => {
         expect(store.getState().description).to.equal('test description');
       });
     });
-    context('query-changed emitted', () => {
+    context('collection-changed emitted', () => {
       beforeEach(() => {
         expect(store.getState().isReadonly).to.equal(false);
-        appRegistry.emit('query-changed', {ns: 'test.coll'});
+        appRegistry.emit('collection-changed', 'test.coll');
       });
-      it('dispatches the readStateChanged action', () => {
-        expect(store.getState().isReadonly).to.equal(true);
+      it('dispatches the readonlyViewChanged action', () => {
+        expect(store.getState().isReadonlyView).to.equal(true);
         expect(store.getState().indexes).to.deep.equal([]);
         expect(store.getState().error).to.equal(null);
       });
@@ -80,8 +80,7 @@ describe('IndexesStore [Store]', () => {
         expect(store.getState().isReadonly).to.equal(false);
         appRegistry.emit('refresh-data');
       });
-      it('dispatches the readStateChanged action', () => {
-        expect(store.getState().isReadonly).to.equal(true);
+      it('dispatches the load indexes action', () => {
         expect(store.getState().indexes).to.deep.equal([]);
         expect(store.getState().error).to.equal(null);
       });


### PR DESCRIPTION
This PR changes 2 main things:

1. The concept of `isReadonly` has been split into 2. `isReadonly` now indicates if the distribution is readonly and `isReadonlyView` indicates if the collection is a readonly view.  In the first case we still show the indexes, but don't show the create index button or the drop index button. In the second case we only render the banner.

2. Index loading now listens to the `collection-changed` event, as we only want to load indexes when the user changes the collection (or refreshes data). Loading indexes on every query change is unexpected. Refreshing data also does not need to update the readonly view value, as the this would never change.