### PR TITLE
COMPASS-3653 - Support for wildcard indexes

### DIFF
--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -6,6 +6,7 @@ import { AppContainer } from 'react-hot-loader';
 import IndexesPlugin, { activate } from 'plugin';
 import DeploymentStateStore from './stores/deployment-state-store';
 import TextWriteButton from './components/text-write-button';
+import { activate as fieldStoreActivate } from '@mongodb-js/compass-field-store';
 import Collation from './components/collation';
 import configureStore, { setDataProvider } from 'stores';
 
@@ -17,6 +18,8 @@ import 'less/index.less';
 
 const appRegistry = new AppRegistry();
 
+const NS = 'venues.restaurants';
+
 global.hadronApp = app;
 global.hadronApp.appRegistry = appRegistry;
 
@@ -25,11 +28,12 @@ activate(appRegistry);
 
 const localAppRegistry = new AppRegistry();
 const store = configureStore({
-  namespace: 'venues.restaurants',
+  namespace: NS,
   isReadonly: false,
   localAppRegistry: localAppRegistry,
   globalAppRegistry: appRegistry
 });
+fieldStoreActivate(localAppRegistry);
 
 appRegistry.registerStore('DeploymentAwareness.WriteStateStore', DeploymentStateStore);
 appRegistry.registerComponent('DeploymentAwareness.TextWriteButton', TextWriteButton);
@@ -50,11 +54,19 @@ const scopedModals = scopedModalRoles.map((role, i) => {
   const scopedStore = role.configureStore({
     localAppRegistry: localAppRegistry,
     globalAppRegistry: appRegistry,
-    namespace: 'echo.artists',
+    namespace: NS,
     isReadonly: false
   });
   return (<role.component store={scopedStore} key={i} />);
 });
+
+const fieldStore = localAppRegistry.getStore('Field.Store');
+const confFieldStore = fieldStore({
+  localAppRegistry: localAppRegistry,
+  namespace: NS
+});
+localAppRegistry.registerStore('Field.Store', confFieldStore);
+
 
 // Create a HMR enabled render function
 const render = Component => {
@@ -91,28 +103,9 @@ const dataService = new DataService(connection);
 dataService.connect((error, ds) => {
   setDataProvider(store, error, ds);
   localAppRegistry.emit('data-service-connected', error, ds);
-  localAppRegistry.emit('fields-changed', {
-    fields: {
-      harry: {
-        name: 'harry', path: 'harry', count: 1, type: 'Number'
-      },
-      potter: {
-        name: 'potter', path: 'potter', count: 1, type: 'Boolean'
-      }
-    },
-    topLevelFields: [ 'harry', 'potter' ],
-    aceFields: [
-      { name: 'harry',
-        value: 'harry',
-        score: 1,
-        meta: 'field',
-        version: '0.0.0' },
-      { name: 'potter',
-        value: 'potter',
-        score: 1,
-        meta: 'field',
-        version: '0.0.0' }
-    ]
+  ds.find(NS, {}, {limit: 1}, (err, s) => {
+    if (err) console.log(`ERROR: ${err.message}`);
+    localAppRegistry.emit('documents-refreshed', null, s);
   });
 });
 

--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -25,7 +25,7 @@ activate(appRegistry);
 
 const localAppRegistry = new AppRegistry();
 const store = configureStore({
-  namespace: 'echo.artists',
+  namespace: 'venues.restaurants',
   isReadonly: false,
   localAppRegistry: localAppRegistry,
   globalAppRegistry: appRegistry

--- a/package-lock.json
+++ b/package-lock.json
@@ -2005,13 +2005,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -2043,6 +2045,7 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
@@ -3913,6 +3916,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -8321,27 +8325,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -8352,15 +8357,17 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8368,39 +8375,42 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
@@ -8410,28 +8420,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -8441,14 +8451,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -8465,7 +8475,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -8480,14 +8490,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -8497,7 +8507,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -8507,7 +8517,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -8518,53 +8528,58 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8572,7 +8587,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -8582,23 +8597,24 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
           "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "dev": true,
           "optional": true,
@@ -8610,7 +8626,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
           "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
           "dev": true,
           "optional": true,
@@ -8629,7 +8645,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -8640,14 +8656,14 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
           "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
           "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
           "dev": true,
           "optional": true,
@@ -8658,7 +8674,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -8671,43 +8687,45 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -8718,21 +8736,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -8745,7 +8763,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -8754,7 +8772,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -8770,7 +8788,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -8780,50 +8798,52 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
           "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8832,7 +8852,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -8842,23 +8862,24 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -8874,14 +8895,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
@@ -8891,15 +8912,17 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9112,13 +9135,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -9516,7 +9541,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "hoist-non-react-statics": {
       "version": "1.2.0",
@@ -14317,9 +14343,9 @@
       }
     },
     "mongodb-index-model": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/mongodb-index-model/-/mongodb-index-model-2.4.0.tgz",
-      "integrity": "sha512-a+3Vq480WdepbBVTd2eYYvN18ldGLfS10FYiFVWyXxENXxxLjuT/0pAMvh+GdxNE8DJ0MYl3s8BlE6M0np4Lgw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb-index-model/-/mongodb-index-model-2.5.0.tgz",
+      "integrity": "sha512-1EEDG7M2NDIiogPWbCCUCDfoBSjX7r9XyHyusakzCYe69ciaTdkS29hh/By/2F5R7gfHr84IVxN4WKjg8k9BGA==",
       "dev": true,
       "requires": {
         "ampersand-collection": "^1.6.1",
@@ -14330,7 +14356,7 @@
         "mongodb": "^3.1.9",
         "mongodb-js-errors": "^0.4.0",
         "mongodb-ns": "^2.0.0",
-        "triejs": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
+        "triejs": "github:rueckstiess/triejs"
       },
       "dependencies": {
         "ampersand-class-extend": {
@@ -14803,9 +14829,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "qs": {
@@ -14875,7 +14901,7 @@
         "lodash.defaults": "^4.2.0",
         "lodash.uniq": "^4.5.0",
         "minimist": "^1.2.0",
-        "pre-commit": "github:mongodb-js/pre-commit#f4158768a7ef58b46808cc09a6f6a0994c0baa67",
+        "pre-commit": "github:mongodb-js/pre-commit",
         "precinct": "^6.1.0"
       },
       "dependencies": {
@@ -16096,13 +16122,13 @@
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
           "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
           "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
@@ -16117,13 +16143,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
@@ -16162,7 +16188,7 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
@@ -16175,13 +16201,13 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
           "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
@@ -16196,7 +16222,7 @@
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
@@ -16215,7 +16241,7 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
@@ -16304,7 +16330,7 @@
         },
         "foreground-child": {
           "version": "1.5.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
           "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
@@ -16314,7 +16340,7 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
@@ -16402,13 +16428,13 @@
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
@@ -16418,7 +16444,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
@@ -16430,25 +16456,25 @@
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
           "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
           "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
@@ -16644,7 +16670,7 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
           "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
           "dev": true,
           "requires": {
@@ -16653,7 +16679,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
@@ -16661,13 +16687,13 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
           "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -16682,7 +16708,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -16723,7 +16749,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
@@ -16732,13 +16758,13 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
@@ -16747,7 +16773,7 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
@@ -16757,7 +16783,7 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
@@ -16780,7 +16806,7 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
@@ -16844,13 +16870,13 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
@@ -16886,7 +16912,7 @@
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
           "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
@@ -16932,13 +16958,13 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
           "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
@@ -16980,13 +17006,13 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
@@ -16995,25 +17021,25 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
           "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "dev": true,
           "requires": {
@@ -17043,7 +17069,7 @@
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
@@ -17059,7 +17085,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
@@ -17084,7 +17110,7 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
           "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
@@ -17153,19 +17179,19 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
@@ -17181,7 +17207,7 @@
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
@@ -17190,7 +17216,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
@@ -17212,7 +17238,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
@@ -17235,7 +17261,7 @@
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
@@ -17719,7 +17745,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
@@ -18077,7 +18104,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,6 +223,12 @@
       "integrity": "sha512-YI+W0V8TmcyRf8BLrLktYPXPC0uqG35jGAROsoqCm4DinYf2iT3yUdBhPULAy1VjiHw7LD4pE59sRqzTu51Hmw==",
       "dev": true
     },
+    "@mongodb-js/compass-field-store": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-field-store/-/compass-field-store-5.0.0.tgz",
+      "integrity": "sha512-kUz8Lb7WSkicYVrTwMYoXT+8P5prv9VcV6o1f7bqDIYm7CqVfD2RAzwirCaxZTmdARa3zmji5ZK6FFPPpbX7Gg==",
+      "dev": true
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-redux": "^5.0.6",
     "react-select-plus": "^1.2.0",
     "react-tooltip": "^3.2.6",
-    "mongodb-index-model": "^2.4.0",
+    "mongodb-index-model": "^2.5.0",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0"
   },
@@ -112,6 +112,7 @@
     "mongodb": "^3.2.0",
     "mongodb-data-service": "^14.0.2",
     "mongodb-extended-json": "^1.10.0",
+    "mongodb-index-model": "^2.5.0",
     "mongodb-js-fmt": "^1.0.0",
     "mongodb-js-precommit": "^2.0.0",
     "mongodb-language-model": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@hot-loader/react-dom": "^16.8.2",
     "@mongodb-js/compass-deployment-awareness": "^6.4.1",
+    "@mongodb-js/compass-field-store": "5.0.0",
     "@storybook/react": "^3.2.0",
     "autoprefixer": "^9.4.6",
     "babel-cli": "^6.10.1",

--- a/src/components/create-index-field/create-index-field.jsx
+++ b/src/components/create-index-field/create-index-field.jsx
@@ -68,7 +68,9 @@ class CreateIndexField extends PureComponent {
    * @param {object} field - The selected field object.
    */
   selectFieldName(field) {
-    this.props.updateFieldName(this.props.idx, field.label);
+    if (field !== null) {
+      this.props.updateFieldName(this.props.idx, field.label);
+    }
   }
 
   /**
@@ -120,7 +122,7 @@ class CreateIndexField extends PureComponent {
           <Select
             value={this.props.field.type}
             placeholder={DEFAULT_FIELD.type}
-            options={this.getDropdownTypes(INDEX_TYPES)}
+            options={this.getDropdownTypes()}
             onChange={this.selectFieldType.bind(this)}
             clearable={false}
             searchable={false}

--- a/src/components/type-column/type-column.jsx
+++ b/src/components/type-column/type-column.jsx
@@ -24,7 +24,7 @@ class TypeColumn extends PureComponent {
   };
 
   _textTooltip() {
-    const info = pick(this.props.index.extra, ['weights', 'default_language', 'language_override']);
+    const info = pick(this.props.index.extra, ['weights', 'default_language', 'language_override', 'wildcardProjection']);
     return map(info, (v, k) => {
       return format('%s: %j', k, v);
     }).join('<br />');
@@ -37,7 +37,7 @@ class TypeColumn extends PureComponent {
    */
   renderType() {
     let tooltipOptions = {};
-    if (this.props.index.type === 'text') {
+    if (this.props.index.type === 'text' || 'wildcard') {
       const tooltipText = `${this._textTooltip()}`;
       tooltipOptions = {
         'data-tip': tooltipText,

--- a/src/components/type-column/type-column.less
+++ b/src/components/type-column/type-column.less
@@ -64,6 +64,15 @@
       .pill(@index-geo-color, @index-geo-bg);
     }
 
+    &-wildcard {
+      display: inline-block;
+      text-align: center;
+      white-space: nowrap;
+      margin-right: 15px;
+      .pill(@index-geo-color, @index-geo-bg);
+    }
+
+
     &-regular {
       display: inline-block;
       text-align: center;

--- a/src/modules/create-index/index.js
+++ b/src/modules/create-index/index.js
@@ -56,9 +56,7 @@ import partialFilterExpression, {
 import name, {
   INITIAL_STATE as NAME_INITIAL_STATE
 } from 'modules/create-index/name';
-import namespace, {
-  INITIAL_STATE as NAMESPACE_INITIAL_STATE
-} from 'modules/namespace';
+import namespace from 'modules/namespace';
 
 import schemaFields from 'modules/create-index/schema-fields';
 import { RESET_FORM } from 'modules/reset-form';
@@ -118,8 +116,7 @@ const rootReducer = (state, action) => {
       ttl: TTL_INITIAL_STATE,
       wildcardProjection: WILDCARD_PROJECTION_INITIAL_STATE,
       partialFilterExpression: PARTIAL_FILTER_EXPRESSION_INITIAL_STATE,
-      name: NAME_INITIAL_STATE,
-      namespace: NAMESPACE_INITIAL_STATE
+      name: NAME_INITIAL_STATE
     };
   }
   return reducer(state, action);
@@ -155,7 +152,8 @@ export const createIndex = () => {
     options.unique = state.isUnique;
     options.name = state.name;
     if (state.name === '') {
-      options.name = `${state.fields[0].name}_${spec[state.fields[0].name]}`;
+      const n = `${state.fields[0].name}_${spec[state.fields[0].name]}`;
+      options.name = n.replace(/\$\*\*/gi, 'wildcard');
     }
     if (state.isCustomCollation) {
       options.collation = state.collation;

--- a/src/modules/create-index/index.js
+++ b/src/modules/create-index/index.js
@@ -184,8 +184,6 @@ export const createIndex = () => {
     dispatch(toggleInProgress(true));
     const ns = state.namespace;
 
-    console.log(`creating index "${JSON.stringify(spec)} with options ${JSON.stringify(options)}`);
-
     state.dataService.createIndex(ns, spec, options, (createErr) => {
       if (!createErr) {
         dispatch(reset());

--- a/src/modules/create-index/is-wildcard.js
+++ b/src/modules/create-index/is-wildcard.js
@@ -1,0 +1,36 @@
+/**
+ * Change is wildcard action name.
+ */
+export const TOGGLE_IS_WILDCARD = 'indexes/create-indexes/is-wildcard/TOGGLE_IS_WILDCARD';
+
+/**
+ * The initial state of the is writable attribute.
+ */
+export const INITIAL_STATE = false;
+
+/**
+ * Reducer function for handle state changes to is wildcard.
+ *
+ * @param {Boolean} state - The is wildcard state.
+ * @param {Object} action - The action.
+ *
+ * @returns {Array} The new state.
+ */
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === TOGGLE_IS_WILDCARD) {
+    return action.isWildcard;
+  }
+  return state;
+}
+
+/**
+ * The toggle is wildcard action creator.
+ *
+ * @param {Boolean} isWildcard - Is wildcard.
+ *
+ * @returns {Object} The action.
+ */
+export const toggleIsWildcard = (isWildcard) => ({
+  type: TOGGLE_IS_WILDCARD,
+  isWildcard: isWildcard
+});

--- a/src/modules/create-index/is-wildcard.spec.js
+++ b/src/modules/create-index/is-wildcard.spec.js
@@ -1,0 +1,30 @@
+import reducer, {
+  INITIAL_STATE,
+  toggleIsWildcard,
+  TOGGLE_IS_WILDCARD
+} from 'modules/create-index/is-wildcard';
+
+describe('create index is wildcard module', () => {
+  describe('#reducer', () => {
+    context('when an action is provided', () => {
+      it('returns the new state', () => {
+        expect(reducer(undefined, toggleIsWildcard(true))).to.equal(true);
+      });
+    });
+
+    context('when an action is not provided', () => {
+      it('returns the default state', () => {
+        expect(reducer(undefined, {})).to.equal(INITIAL_STATE);
+      });
+    });
+  });
+
+  describe('#toggleIsWildcard', () => {
+    it('returns the action', () => {
+      expect(toggleIsWildcard(false)).to.deep.equal({
+        type: TOGGLE_IS_WILDCARD,
+        isWildcard: false
+      });
+    });
+  });
+});

--- a/src/modules/create-index/wildcard-projection.js
+++ b/src/modules/create-index/wildcard-projection.js
@@ -1,0 +1,36 @@
+/**
+ * Create index wildcard projection action.
+ */
+export const CHANGE_WILDCARD_PROJECTION = 'indexes/create-index/wildcard-projection/CHANGE_WILDCARD_PROJECTION';
+
+/**
+ * The initial state of the wildcard projection.
+ */
+export const INITIAL_STATE = '';
+
+/**
+ * Reducer function for handle state changes to create wildcard projection.
+ *
+ * @param {String} state - The create wildcard projection state.
+ * @param {Object} action - The action.
+ *
+ * @returns {String} The new state.
+ */
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === CHANGE_WILDCARD_PROJECTION) {
+    return action.wildcardProjection;
+  }
+  return state;
+}
+
+/**
+ * The change wildcard projection action creator.
+ *
+ * @param {String} wildcardProjection - The wildcard projection.
+ *
+ * @returns {Object} The action.
+ */
+export const changeWildcardProjection = (wildcardProjection) => ({
+  type: CHANGE_WILDCARD_PROJECTION,
+  wildcardProjection: wildcardProjection
+});

--- a/src/modules/create-index/wildcard-projection.spec.js
+++ b/src/modules/create-index/wildcard-projection.spec.js
@@ -1,0 +1,32 @@
+import reducer, {
+  INITIAL_STATE,
+  changeWildcardProjection,
+  CHANGE_WILDCARD_PROJECTION
+} from 'modules/create-index/wildcard-projection';
+
+describe('create index wildcard projection module', () => {
+  describe('#reducer', () => {
+    context('when an action is provided', () => {
+      it('returns the new state', () => {
+        expect(
+          reducer(undefined, changeWildcardProjection({'testkey': 'testvalue'}))
+        ).to.deep.equal({'testkey': 'testvalue'});
+      });
+    });
+
+    context('when an action is not provided', () => {
+      it('returns the default state', () => {
+        expect(reducer(undefined, {})).to.equal(INITIAL_STATE);
+      });
+    });
+  });
+
+  describe('#changeWildcardProjection', () => {
+    it('returns the action', () => {
+      expect(changeWildcardProjection({'testkey': 'testvalue'})).to.deep.equal({
+        type: CHANGE_WILDCARD_PROJECTION,
+        wildcardProjection: {'testkey': 'testvalue'}
+      });
+    });
+  });
+});

--- a/src/modules/drop-index/index.js
+++ b/src/modules/drop-index/index.js
@@ -26,9 +26,7 @@ import confirmName, {
 import { RESET_FORM } from 'modules/reset-form';
 import { RESET, reset } from 'modules/reset';
 import { parseErrorMsg } from 'modules/indexes';
-import namespace, {
-  INITIAL_STATE as NAMESPACE_INITIAL_STATE
-} from 'modules/namespace';
+import namespace from 'modules/namespace';
 
 /**
  * The main reducer.
@@ -60,8 +58,7 @@ const rootReducer = (state, action) => {
       isVisible: IS_VISIBLE_INITIAL_STATE,
       error: ERROR_INITIAL_STATE,
       name: NAME_INITIAL_STATE,
-      confirmName: CONFIRM_NAME_INITIAL_STATE,
-      namespace: NAMESPACE_INITIAL_STATE
+      confirmName: CONFIRM_NAME_INITIAL_STATE
     };
   }
   return reducer(state, action);

--- a/src/modules/indexes.js
+++ b/src/modules/indexes.js
@@ -100,9 +100,9 @@ const _field = (f) => {
  * @returns {Array} The index models.
  */
 const _convertToModels = (indexes) => {
-  const maxSize = max(indexes, (index) => {
+  const maxSize = max(indexes.map((index) => {
     return index.size;
-  }).size;
+  }));
   return map(indexes, (index) => {
     const model = new IndexModel(new IndexModel().parse(index));
     model.relativeSize = model.size / maxSize * 100;

--- a/src/modules/indexes.spec.js
+++ b/src/modules/indexes.spec.js
@@ -214,7 +214,7 @@ const defaultSort = [
       'partialFilterExpression': {'y': 1}}, 'id': 'citibike.trips.AAAA',
     'unique': false, 'sparse': false, 'ttl': true, 'hashed': false,
     'geo': false, 'compound': false, 'single': true, 'partial': true,
-    'text': false, 'collation': false, 'type': 'regular',
+    'text': false, 'wildcard': false, 'collation': false, 'type': 'regular',
     'cardinality': 'single', 'properties': ['partial', 'ttl']
   },
   {
@@ -228,7 +228,7 @@ const defaultSort = [
         'normalization': true, 'backwards': true, 'version': '57.1'}},
     'id': 'citibike.trips.BBBB', 'unique': false, 'sparse': false,
     'ttl': false, 'hashed': false, 'geo': false, 'compound': false,
-    'single': true, 'partial': false, 'text': false, 'collation': true,
+    'single': true, 'partial': false, 'text': false, 'wildcard': false, 'collation': true,
     'type': 'regular', 'cardinality': 'single', 'properties': ['collation']
   },
   {
@@ -239,7 +239,7 @@ const defaultSort = [
     'extra': {'background': false, '2dsphereIndexVersion': 3},
     'id': 'citibike.trips.CCCC', 'unique': false, 'sparse': false,
     'ttl': false, 'hashed': false, 'geo': true, 'compound': true,
-    'single': false, 'partial': false, 'text': false, 'collation': false,
+    'single': false, 'partial': false, 'text': false, 'wildcard': false, 'collation': false,
     'type': 'geospatial', 'cardinality': 'compound', 'properties': []
   },
   {
@@ -248,7 +248,7 @@ const defaultSort = [
     'usageHost': 'computername.local:27017', 'version': 2, 'extra': {},
     'id': 'citibike.trips._id_', 'unique': true, 'sparse': false,
     'ttl': false, 'hashed': false, 'geo': false, 'compound': false,
-    'single': true, 'partial': false, 'text': false, 'collation': false,
+    'single': true, 'partial': false, 'text': false, 'wildcard': false, 'collation': false,
     'type': 'regular', 'cardinality': 'single', 'properties': ['unique']
   }
 ];
@@ -264,7 +264,7 @@ const usageSort = [
     'extra': {'background': false, 'expireAfterSeconds': 300,
       'partialFilterExpression': {'y': 1}}, 'id': 'citibike.trips.AAAA',
     'unique': false, 'sparse': false, 'ttl': true, 'hashed': false, 'geo': false,
-    'compound': false, 'single': true, 'partial': true, 'text': false,
+    'compound': false, 'single': true, 'partial': true, 'text': false, 'wildcard': false,
     'collation': false, 'type': 'regular', 'cardinality': 'single',
     'properties': ['partial', 'ttl']
   },
@@ -277,7 +277,7 @@ const usageSort = [
     'version': 2, 'extra': {'background': false, '2dsphereIndexVersion': 3},
     'id': 'citibike.trips.CCCC', 'unique': false, 'sparse': false,
     'ttl': false, 'hashed': false, 'geo': true, 'compound': true,
-    'single': false, 'partial': false, 'text': false, 'collation': false,
+    'single': false, 'partial': false, 'text': false, 'wildcard': false, 'collation': false,
     'type': 'geospatial', 'cardinality': 'compound', 'properties': []
   },
   {
@@ -288,7 +288,7 @@ const usageSort = [
     'usageHost': 'computername.local:27017', 'version': 2, 'extra': {},
     'id': 'citibike.trips._id_', 'unique': true, 'sparse': false, 'ttl': false,
     'hashed': false, 'geo': false, 'compound': false, 'single': true,
-    'partial': false, 'text': false, 'collation': false, 'type': 'regular',
+    'partial': false, 'text': false, 'wildcard': false, 'collation': false, 'type': 'regular',
     'cardinality': 'single', 'properties': ['unique']
   },
   {
@@ -303,7 +303,7 @@ const usageSort = [
         'normalization': true, 'backwards': true, 'version': '57.1'}},
     'id': 'citibike.trips.BBBB', 'unique': false, 'sparse': false,
     'ttl': false, 'hashed': false, 'geo': false, 'compound': false,
-    'single': true, 'partial': false, 'text': false, 'collation': true,
+    'single': true, 'partial': false, 'text': false, 'wildcard': false, 'collation': true,
     'type': 'regular', 'cardinality': 'single', 'properties': ['collation']
   }
 ];

--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -42,6 +42,7 @@ const configureStore = (options = {}) => {
     localAppRegistry.on('refresh-data', () => {
       store.dispatch(loadIndexesFromDb());
     });
+    // TODO: could save the version to check for wildcard indexes
   }
 
   if (options.globalAppRegistry) {

--- a/src/utils/index-link-helper.js
+++ b/src/utils/index-link-helper.js
@@ -9,6 +9,7 @@ const HELP_URLS = {
   '2DSPHERE': 'https://docs.mongodb.org/manual/core/2dsphere/',
   GEOHAYSTACK: 'https://docs.mongodb.org/manual/core/geohaystack/',
   GEOSPATIAL: 'https://docs.mongodb.org/manual/applications/geospatial-indexes/#geospatial-indexes',
+  WILDCARD: 'https://docs.mongodb.org/manual/core/wildcard/',
   TEXT: 'https://docs.mongodb.org/manual/core/index-text/',
   HASHED: 'https://docs.mongodb.org/manual/core/index-hashed/',
   REGULAR: 'https://docs.mongodb.com/manual/indexes/#single-field',

--- a/src/utils/index-link-helper.js
+++ b/src/utils/index-link-helper.js
@@ -2,6 +2,7 @@ const HELP_URLS = {
   SINGLE: 'https://docs.mongodb.org/manual/core/index-single/',
   COMPOUND: 'https://docs.mongodb.org/manual/core/index-compound/',
   UNIQUE: 'https://docs.mongodb.org/manual/core/index-unique/',
+  BACKGROUND: 'https://docs.mongodb.com/manual/core/index-creation/#index-creation-background',
   PARTIAL: 'https://docs.mongodb.org/manual/core/index-partial/',
   SPARSE: 'https://docs.mongodb.org/manual/core/index-sparse/',
   TTL: 'https://docs.mongodb.org/manual/core/index-ttl/',
@@ -14,6 +15,7 @@ const HELP_URLS = {
   HASHED: 'https://docs.mongodb.org/manual/core/index-hashed/',
   REGULAR: 'https://docs.mongodb.com/manual/indexes/#single-field',
   COLLATION: 'https://docs.mongodb.com/master/reference/bson-type-comparison-order/#collation',
+  COLLATION_REF: 'https://docs.mongodb.com/master/reference/collation',
   UNKNOWN: null
 };
 


### PR DESCRIPTION
Adds support for visualizing wildcard indexes:

<img width="1020" alt="Screen Shot 2019-06-11 at 3 43 08 PM" src="https://user-images.githubusercontent.com/1045019/59276986-a2a4c580-8c5f-11e9-9ff9-4490b1c9b25d.png">

Also adds **bare bones** support for creating new wildcard indexes. 100% of the correctness checking is left to the server and the user is responsible for setting the key themselves. For example:

![wildcard](https://user-images.githubusercontent.com/1045019/59278149-c49f4780-8c61-11e9-8484-6482233e9709.gif)

So if the user decides to have a malformed wildcard projection, or a multi-key index, or a wildcard projection without a $** in the key, then whatever error the server returns is what's indicated.

This also fixes 2 bugs: clearing namespace on reset for modals + size calculations were not being done correctly)