### PR TITLE
COMPASS-4371 - Account for missing 'ns' field

### DIFF
--- a/src/modules/indexes.js
+++ b/src/modules/indexes.js
@@ -196,12 +196,18 @@ export const loadIndexesFromDb = () => {
       dispatch(loadIndexes([]));
       dispatch(localAppRegistryEmit('indexes-changed', []));
     } else {
+      const ns = state.namespace;
       state.dataService.indexes(state.namespace, {}, (err, indexes) => {
         if (err) {
           dispatch(handleError(parseErrorMsg(err)));
           dispatch(loadIndexes([]));
           dispatch(localAppRegistryEmit('indexes-changed', []));
         } else {
+          // Set the `ns` field manually as it is not returned from the server
+          // since version 4.4.
+          for (const index of indexes) {
+            index.ns = ns;
+          }
           const ixs = modelAndSort(indexes, state.sortColumn, state.sortOrder);
           dispatch(loadIndexes(ixs));
           dispatch(localAppRegistryEmit('indexes-changed', ixs));

--- a/src/modules/indexes.spec.js
+++ b/src/modules/indexes.spec.js
@@ -110,7 +110,7 @@ describe('indexes module', () => {
           emit: emitSpy
         },
         isReadonly: true,
-        namespace: 'citibikes.trips'
+        namespace: 'citibike.trips'
       });
       loadIndexesFromDb()(dispatch, state);
       expect(actionSpy.calledOnce).to.equal(true);
@@ -138,7 +138,7 @@ describe('indexes module', () => {
         dataService: {
           indexes: (ns, opts, cb) => { cb({message: 'error message!'}); }
         },
-        namespace: 'citibikes.trips'
+        namespace: 'citibike.trips'
       });
       loadIndexesFromDb()(dispatch, state);
       expect(actionSpy.calledTwice).to.equal(true);
@@ -165,7 +165,7 @@ describe('indexes module', () => {
         },
         sortColumn: DEFAULT,
         sortOrder: ASC,
-        namespace: 'citibikes.trips'
+        namespace: 'citibike.trips'
       });
       loadIndexesFromDb()(dispatch, state);
       expect(actionSpy.calledOnce).to.equal(true);
@@ -177,25 +177,25 @@ describe('indexes module', () => {
 const fromDB = [
   {
     'name': '_id_',
-    'v': 2, 'key': {'_id': 1}, 'ns': 'citibike.trips',
+    'v': 2, 'key': {'_id': 1},
     'usageHost': 'computername.local:27017', 'usageCount': 6,
     'usageSince': '2019-02-08T10:21:49.176Z', 'size': 135168
   }, {
     'name': 'CCCC',
     'v': 2, 'key': {'cccc0': -1, 'cccc1': '2dsphere', 'cccc2': 1},
-    'ns': 'citibike.trips', 'background': false, '2dsphereIndexVersion': 3,
+    'background': false, '2dsphereIndexVersion': 3,
     'usageHost': 'computername.local:27017', 'usageCount': 5,
     'usageSince': '2019-02-08T14:38:56.147Z', 'size': 4096
   }, {
     'name': 'AAAA',
     'v': 2, 'key': {'aaaa': -1},
-    'ns': 'citibike.trips', 'background': false,
+    'background': false,
     'expireAfterSeconds': 300, 'partialFilterExpression': {'y': 1},
     'usageHost': 'computername.local:27017', 'usageCount': 4,
     'usageSince': '2019-02-08T14:39:56.285Z', 'size': 4096
   }, {
     'name': 'BBBB',
-    'v': 2, 'key': {'bbbb.abcd': 1}, 'ns': 'citibike.trips',
+    'v': 2, 'key': {'bbbb.abcd': 1},
     'background': false, 'collation': {'locale': 'ar', 'caseLevel': true,
       'caseFirst': 'lower', 'strength': 3, 'numericOrdering': false,
       'alternate': 'non-ignorable', 'maxVariable': 'space',


### PR DESCRIPTION
As of MongoDB 4.4, the server does not return an `ns` field
when using `listIndexes`. Therefore, we add it ourselves
based on the original input to the query.

We are not using the field directly in the source code, but
`monogbd-index-model` uses ot to derive its `id` field.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
