### PR TITLE
fix: Check if dataService is connected before trying to refresh indexes COMPASS-4741 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -308,6 +308,12 @@
       "integrity": "sha512-L/rtA3iLeJ3rtaOnj7iYp+fa+gHZhoYRrDo2dDqG8l90jp2yjt7HSyzn88YCgfFk6pHmYXz+v/M9UYVvA4viKg==",
       "dev": true
     },
+    "@mongodb-js/triejs": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/triejs/-/triejs-0.1.5.tgz",
+      "integrity": "sha512-elh8S1OxmEGe8/wbr6ky//dHhV2ld6oZV8/M9lgozJsL/6Aqm8j5+ElquzoX9k9l3Q+dohuX/SIGR/kTRZHS4g==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -3132,6 +3138,7 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
       "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
       "dev": true,
+      "optional": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -11411,7 +11418,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
       "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lodash.clone": {
       "version": "3.0.3",
@@ -12202,7 +12210,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -13446,11 +13455,18 @@
         }
       }
     },
+    "mongodb-build-info": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.1.tgz",
+      "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g==",
+      "dev": true
+    },
     "mongodb-collection-sample": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/mongodb-collection-sample/-/mongodb-collection-sample-4.5.1.tgz",
       "integrity": "sha512-tUCdRLToheOh2Tn+KVdhYtbLifxCo60+wVMf0zxtbZLKPYbZqQaYmyrYTsEunePNJyxIutBWdayX79VJ/Fb2hg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "bson": "^4.0.3",
         "debug": "^4.1.1",
@@ -13468,6 +13484,7 @@
           "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.3.tgz",
           "integrity": "sha512-7uBjjxwOSuGLmoqGI1UXWpDGc0K2WjR7dC6iaOg4iriNZo6M2EEBb8co4dEPJ5ArYCebPMie0ecgX0TWF+ZUrQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer": "^5.1.0",
             "long": "^4.0.0"
@@ -13478,6 +13495,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -13510,40 +13528,249 @@
       }
     },
     "mongodb-data-service": {
-      "version": "16.5.5",
-      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-16.5.5.tgz",
-      "integrity": "sha512-Y3XgagtjFvSqdAMujqG3jrXzBQS7DKsXNd7XR4jJLbiJKOoP/cD12DgTan6VFy43d+DzP/KF8cTv20YBbUwa7w==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-19.2.0.tgz",
+      "integrity": "sha512-BUnNPHmSO1DQytG1DeKm6MM0Ia3ySAFckA8NaYR2MRWnCaf/Smg4Ldw72HCOS8NGWK7JZzqAmP+kOJco0B8XLQ==",
       "dev": true,
       "requires": {
-        "async": "^3.1.0",
-        "debug": "^4.1.1",
-        "lodash": "^4.17.0",
-        "mongodb": "^3.5.2",
-        "mongodb-collection-sample": "^4.4.4",
-        "mongodb-connection-model": "^14.6.2",
-        "mongodb-index-model": "^2.5.0",
+        "async": "^3.2.0",
+        "debug": "^4.2.0",
+        "lodash": "^4.17.20",
+        "mongodb-build-info": "^1.1.1",
+        "mongodb-index-model": "^2.6.1",
         "mongodb-js-errors": "^0.5.0",
-        "mongodb-ns": "^2.0.0",
+        "mongodb-ns": "^2.2.0",
         "mongodb-security": "^0.2.0",
         "mongodb-url": "^3.0.3"
       },
       "dependencies": {
-        "mongodb-connection-model": {
-          "version": "14.6.2",
-          "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-14.6.2.tgz",
-          "integrity": "sha512-Xa0jLNT+1j4n4NTxNiGQ+3fOQrrSuX37Bme9xFvnZe12XADS9770eb4BMOrT/FgnPY3OSzDt3CyWDyrMPcZsuA==",
+        "ampersand-class-extend": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ampersand-class-extend/-/ampersand-class-extend-1.0.2.tgz",
+          "integrity": "sha1-jjqxJdCb976UO1DpjM5G/1F8vpE=",
           "dev": true,
           "requires": {
-            "ampersand-model": "^8.0.0",
+            "lodash.assign": "^3.0.0"
+          }
+        },
+        "ampersand-collection": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/ampersand-collection/-/ampersand-collection-1.6.1.tgz",
+          "integrity": "sha1-Qw9lTPcC4Z0drGzSEXVdUDFyoMk=",
+          "dev": true,
+          "requires": {
+            "ampersand-class-extend": "^1.0.0",
+            "ampersand-events": "^1.0.1",
+            "ampersand-version": "^1.0.2",
+            "lodash.assign": "^3.0.0",
+            "lodash.bind": "^3.1.0",
+            "lodash.isarray": "^3.0.1"
+          }
+        },
+        "ampersand-events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-1.1.1.tgz",
+          "integrity": "sha1-pQDpjMrorZKqHZV0TFM9nBChZTA=",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.2",
+            "lodash.assign": "^3.0.0",
+            "lodash.bind": "^3.1.0",
+            "lodash.foreach": "^3.0.2",
+            "lodash.isempty": "^3.0.1",
+            "lodash.keys": "^3.0.5",
+            "lodash.once": "^3.0.0",
+            "lodash.uniqueid": "^3.0.0"
+          }
+        },
+        "ampersand-model": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/ampersand-model/-/ampersand-model-6.0.3.tgz",
+          "integrity": "sha1-x+zlpnFVFT4TxyR1rPF4szhKVXw=",
+          "dev": true,
+          "requires": {
+            "ampersand-state": "^4.6.0",
+            "ampersand-sync": "^4.0.3",
+            "ampersand-version": "^1.0.2",
+            "lodash.assign": "^3.2.0",
+            "lodash.clone": "^3.0.3",
+            "lodash.isobject": "^3.0.2",
+            "lodash.result": "^3.1.2"
+          }
+        },
+        "ampersand-state": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-4.8.2.tgz",
+          "integrity": "sha1-qPrjZakZ54S8icbqk6PzXvcvLDk=",
+          "dev": true,
+          "requires": {
+            "ampersand-events": "^1.1.1",
+            "ampersand-version": "^1.0.0",
+            "array-next": "~0.0.1",
+            "key-tree-store": "^1.3.0",
+            "lodash.assign": "^3.2.0",
+            "lodash.bind": "^3.1.0",
+            "lodash.escape": "^3.0.0",
+            "lodash.forown": "^3.0.2",
+            "lodash.has": "^3.0.0",
+            "lodash.includes": "^3.1.3",
+            "lodash.isarray": "^3.0.4",
+            "lodash.isdate": "^3.0.1",
+            "lodash.isequal": "^3.0.1",
+            "lodash.isfunction": "^3.0.6",
+            "lodash.isobject": "^3.0.1",
+            "lodash.isstring": "^3.0.1",
+            "lodash.omit": "^3.1.0",
+            "lodash.result": "^3.0.0",
+            "lodash.union": "^3.1.0",
+            "lodash.uniqueid": "^3.0.0"
+          }
+        },
+        "ampersand-sync": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/ampersand-sync/-/ampersand-sync-4.0.3.tgz",
+          "integrity": "sha1-wlXWBYhZUxRyEJ+KULocCtnY1yU=",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.0",
+            "lodash.assign": "^3.0.0",
+            "lodash.defaults": "^3.1.0",
+            "lodash.includes": "^3.1.0",
+            "lodash.result": "^3.0.0",
+            "media-type": "0.3.0",
+            "qs": "^4.0.0",
+            "request": "^2.55.0",
+            "xhr": "^2.0.5"
+          }
+        },
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+          "dev": true
+        },
+        "bl": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+          "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "bson": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+          "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
+        "lodash.defaults": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+          "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
+          "dev": true,
+          "requires": {
+            "lodash.assign": "^3.0.0",
+            "lodash.restparam": "^3.0.0"
+          }
+        },
+        "mongodb": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.5.tgz",
+          "integrity": "sha512-mQlYKw1iGbvJJejcPuyTaytq0xxlYbIoVDm2FODR+OHxyEiMR021vc32bTvamgBjCswsD54XIRwhg3yBaWqJjg==",
+          "dev": true,
+          "requires": {
+            "bl": "^2.2.1",
+            "bson": "^1.1.4",
+            "denque": "^1.4.1",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        },
+        "mongodb-index-model": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/mongodb-index-model/-/mongodb-index-model-2.6.1.tgz",
+          "integrity": "sha512-F6CktBkd0U2uV1y8r6PhZQiKqAUND0HmZvlFMRqXnhPqGSI+SbiTaKxcwPUbXPzikGBSL8KaAujFGf/y41N0Tw==",
+          "dev": true,
+          "requires": {
+            "@mongodb-js/triejs": "^0.1.5",
+            "ampersand-collection": "^1.6.1",
+            "ampersand-model": "^6.0.2",
             "ampersand-rest-collection": "^6.0.0",
-            "async": "^3.1.0",
-            "debug": "^4.1.1",
-            "kerberos": "^1.1.3",
+            "async": "^3.2.0",
             "lodash": "^4.17.15",
-            "mongodb": "^3.5.2",
-            "raf": "^3.4.1",
-            "ssh2": "^0.8.7",
-            "storage-mixin": "^3.2.7"
+            "mongodb": "^3.5.4",
+            "mongodb-js-errors": "^0.5.0",
+            "mongodb-ns": "^2.2.0"
+          }
+        },
+        "qs": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "mocha-webpack": "^2.0.0-beta.0",
     "mongodb": "^3.5.2",
     "mongodb-connection-model": "^14.5.1",
-    "mongodb-data-service": "^16.5.2",
+    "mongodb-data-service": "^19.2.0",
     "mongodb-extended-json": "^1.11.0",
     "mongodb-index-model": "^2.5.0",
     "mongodb-js-precommit": "^2.2.1",

--- a/src/modules/indexes.js
+++ b/src/modules/indexes.js
@@ -1,3 +1,5 @@
+const debug = require('debug')('mongodb-compass:modules:indexes');
+
 import IndexModel from 'mongodb-index-model';
 import map from 'lodash.map';
 import max from 'lodash.max';
@@ -195,7 +197,7 @@ export const loadIndexesFromDb = () => {
     if (state.isReadonly) {
       dispatch(loadIndexes([]));
       dispatch(localAppRegistryEmit('indexes-changed', []));
-    } else {
+    } else if (state.dataService && state.dataService.isConnected()) {
       const ns = state.namespace;
       state.dataService.indexes(state.namespace, {}, (err, indexes) => {
         if (err) {
@@ -213,6 +215,11 @@ export const loadIndexesFromDb = () => {
           dispatch(localAppRegistryEmit('indexes-changed', ixs));
         }
       });
+    } else if (state.dataService && !state.dataService.isConnected()) {
+      debug(
+        'warning: trying to load indexes but dataService is disconnected',
+        state.dataService
+      );
     }
   };
 };


### PR DESCRIPTION
This is an intermediate workaround for a leaky compass plugins issue. We don't expect `dataService` to be disconnected when these actions are dispatched ever, so technically throwing in this case might've been a right thing to do, but currently as a workaround for leaking listeners of `refresh-data` event, we just warn and no-op if `dataService` is disconnected